### PR TITLE
feat(DMD-1071): add targetServiceAccountEmail and listing sharing fields to BQ protos

### DIFF
--- a/generated/Keboola/StorageDriver/Command/Bucket/GrantBucketAccessToReadOnlyRoleResponse.php
+++ b/generated/Keboola/StorageDriver/Command/Bucket/GrantBucketAccessToReadOnlyRoleResponse.php
@@ -22,6 +22,18 @@ class GrantBucketAccessToReadOnlyRoleResponse extends \Google\Protobuf\Internal\
      * Generated from protobuf field <code>string createBucketObjectName = 1;</code>
      */
     protected $createBucketObjectName = '';
+    /**
+     * Analytics Hub listing resource name (BQ external buckets only); empty string if not applicable
+     *
+     * Generated from protobuf field <code>string sourceListing = 2;</code>
+     */
+    protected $sourceListing = '';
+    /**
+     * true if KBC SA has listingAdmin on the listing, allowing setIamPolicy calls (BQ external buckets only)
+     *
+     * Generated from protobuf field <code>bool sourceListingSharingAllowed = 3;</code>
+     */
+    protected $sourceListingSharingAllowed = false;
 
     /**
      * Constructor.
@@ -31,6 +43,10 @@ class GrantBucketAccessToReadOnlyRoleResponse extends \Google\Protobuf\Internal\
      *
      *     @type string $createBucketObjectName
      *           resulting object name actually stored in backend
+     *     @type string $sourceListing
+     *           Analytics Hub listing resource name (BQ external buckets only); empty string if not applicable
+     *     @type bool $sourceListingSharingAllowed
+     *           true if KBC SA has listingAdmin on the listing, allowing setIamPolicy calls (BQ external buckets only)
      * }
      */
     public function __construct($data = NULL) {
@@ -60,6 +76,58 @@ class GrantBucketAccessToReadOnlyRoleResponse extends \Google\Protobuf\Internal\
     {
         GPBUtil::checkString($var, True);
         $this->createBucketObjectName = $var;
+
+        return $this;
+    }
+
+    /**
+     * Analytics Hub listing resource name (BQ external buckets only); empty string if not applicable
+     *
+     * Generated from protobuf field <code>string sourceListing = 2;</code>
+     * @return string
+     */
+    public function getSourceListing()
+    {
+        return $this->sourceListing;
+    }
+
+    /**
+     * Analytics Hub listing resource name (BQ external buckets only); empty string if not applicable
+     *
+     * Generated from protobuf field <code>string sourceListing = 2;</code>
+     * @param string $var
+     * @return $this
+     */
+    public function setSourceListing($var)
+    {
+        GPBUtil::checkString($var, True);
+        $this->sourceListing = $var;
+
+        return $this;
+    }
+
+    /**
+     * true if KBC SA has listingAdmin on the listing, allowing setIamPolicy calls (BQ external buckets only)
+     *
+     * Generated from protobuf field <code>bool sourceListingSharingAllowed = 3;</code>
+     * @return bool
+     */
+    public function getSourceListingSharingAllowed()
+    {
+        return $this->sourceListingSharingAllowed;
+    }
+
+    /**
+     * true if KBC SA has listingAdmin on the listing, allowing setIamPolicy calls (BQ external buckets only)
+     *
+     * Generated from protobuf field <code>bool sourceListingSharingAllowed = 3;</code>
+     * @param bool $var
+     * @return $this
+     */
+    public function setSourceListingSharingAllowed($var)
+    {
+        GPBUtil::checkBool($var);
+        $this->sourceListingSharingAllowed = $var;
 
         return $this;
     }

--- a/generated/Keboola/StorageDriver/Command/Bucket/LinkBucketCommand/LinkBucketBigqueryMeta.php
+++ b/generated/Keboola/StorageDriver/Command/Bucket/LinkBucketCommand/LinkBucketBigqueryMeta.php
@@ -20,6 +20,12 @@ class LinkBucketBigqueryMeta extends \Google\Protobuf\Internal\Message
      * @deprecated
      */
     protected $region = '';
+    /**
+     * email of KBC2 project service account; required when linking external BQ buckets where the driver must grant subscriber access to this SA
+     *
+     * Generated from protobuf field <code>string targetServiceAccountEmail = 2;</code>
+     */
+    protected $targetServiceAccountEmail = '';
 
     /**
      * Constructor.
@@ -29,6 +35,8 @@ class LinkBucketBigqueryMeta extends \Google\Protobuf\Internal\Message
      *
      *     @type string $region
      *           region where linked bucket is created
+     *     @type string $targetServiceAccountEmail
+     *           email of KBC2 project service account; required when linking external BQ buckets where the driver must grant subscriber access to this SA
      * }
      */
     public function __construct($data = NULL) {
@@ -62,6 +70,32 @@ class LinkBucketBigqueryMeta extends \Google\Protobuf\Internal\Message
         @trigger_error('region is deprecated.', E_USER_DEPRECATED);
         GPBUtil::checkString($var, True);
         $this->region = $var;
+
+        return $this;
+    }
+
+    /**
+     * email of KBC2 project service account; required when linking external BQ buckets where the driver must grant subscriber access to this SA
+     *
+     * Generated from protobuf field <code>string targetServiceAccountEmail = 2;</code>
+     * @return string
+     */
+    public function getTargetServiceAccountEmail()
+    {
+        return $this->targetServiceAccountEmail;
+    }
+
+    /**
+     * email of KBC2 project service account; required when linking external BQ buckets where the driver must grant subscriber access to this SA
+     *
+     * Generated from protobuf field <code>string targetServiceAccountEmail = 2;</code>
+     * @param string $var
+     * @return $this
+     */
+    public function setTargetServiceAccountEmail($var)
+    {
+        GPBUtil::checkString($var, True);
+        $this->targetServiceAccountEmail = $var;
 
         return $this;
     }

--- a/proto/bucket.proto
+++ b/proto/bucket.proto
@@ -61,6 +61,7 @@ message LinkBucketCommand {
 
   message LinkBucketBigqueryMeta {
     string region = 1 [deprecated = true]; // region where linked bucket is created
+    string targetServiceAccountEmail = 2; // email of KBC2 project service account; required when linking external BQ buckets where the driver must grant subscriber access to this SA
   }
 }
 
@@ -126,6 +127,8 @@ message GrantBucketAccessToReadOnlyRoleCommand {
  */
 message GrantBucketAccessToReadOnlyRoleResponse {
   string createBucketObjectName = 1; // resulting object name actually stored in backend
+  string sourceListing = 2; // Analytics Hub listing resource name (BQ external buckets only); empty string if not applicable
+  bool sourceListingSharingAllowed = 3; // true if KBC SA has listingAdmin on the listing, allowing setIamPolicy calls (BQ external buckets only)
 }
 
 message RevokeBucketAccessFromReadOnlyRoleCommand {


### PR DESCRIPTION
Linear: DMD-1071
Connection PR: https://github.com/keboola/connection/pull/6727
Driver-BQ PR: https://github.com/keboola/php-storage-driver-bigquery/pull/198

---
## Summary

Add proto fields needed for BigQuery external bucket sharing (Solution A - Analytics Hub IAM-based sharing).

### What changed

**`proto/bucket.proto`**:

- `LinkBucketCommand.LinkBucketBigqueryMeta`: new field `targetServiceAccountEmail = 2`
  - When non-empty, signals to the driver that this is an external listing link
  - The driver will grant `roles/analyticshub.subscriber` to this SA on the listing before subscribing

- `GrantBucketAccessToReadOnlyRoleResponse`: two new fields
  - `sourceListing = 2`: Analytics Hub listing resource name (empty for non-external buckets)
  - `sourceListingSharingAllowed = 3`: whether the KBC SA has `listingAdmin` on the listing (i.e., can call `setIamPolicy` to grant subscriber access to other projects)

**Generated PHP classes** updated to match (manually, as protoc is not run in CI for PHP):
- `generated/Keboola/StorageDriver/Command/Bucket/LinkBucketCommand/LinkBucketBigqueryMeta.php`
- `generated/Keboola/StorageDriver/Command/Bucket/GrantBucketAccessToReadOnlyRoleResponse.php`
